### PR TITLE
Missing comma in Default.sublime-commands

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -76,7 +76,7 @@
     {
         "caption": "SublimeGDB: Open Breakpoint View",
         "command": "gdb_open_breakpoint_view"
-    }
+    },
     {
         "caption": "SublimeGDB: Open Threads View",
         "command": "gdb_open_threads_view"


### PR DESCRIPTION
The console reports

> Error loading commands: Error trying to parse file: Unexpected character, expected a comma or closing bracket in ~/Library/Application Support/Sublime Text 2/Packages/SublimeGDB/Default.sublime-commands:80:5
