### PR TITLE
run_cmd can take list of commands as input

### DIFF
--- a/sublimegdb.py
+++ b/sublimegdb.py
@@ -1158,6 +1158,12 @@ def run_cmd(cmd, block=False, mimode=True, timeout=10):
 
     timeoutcount = timeout/0.001
 
+    ### handle a list of commands by recursively calling run_cmd
+    if isinstance(cmd, list):
+        for c in cmd:
+            run_cmd(c, block, mimode, timeout)
+        return count
+
     if mimode:
         count = count + 1
         cmd = "%d%s\n" % (count, cmd)


### PR DESCRIPTION
patch to allow run_cmd to also take a list of commands. It allows configs such as:

```
        "sublimegdb_exec_cmd" : [
            "target remote localhost:3333",
            "monitor reset halt",
            "load build/ch.elf",
            "monitor reset halt",
            "continue"
        ]
```

Each command will have its own timeout. Maybe the timeout should apply to the whole set of commands? I'm not sure of the best behaviour
