### PR TITLE
Add 'debug_ext' option to the sublime-settings file. 

### DIFF
--- a/SublimeGDB.sublime-settings
+++ b/SublimeGDB.sublime-settings
@@ -87,6 +87,10 @@
     // Setting it to "stdout" will write the output to the python console
     "debug_file": "stdout",
 
+    // Add "pending breakpoints" for symbols that are dynamically loaded from
+    // external shared libraries
+    "debug_ext" : false,
+
     // Whether to log the raw data read from and written to the gdb session and the inferior program.
     "debug": false
 }

--- a/sublimegdb.py
+++ b/sublimegdb.py
@@ -1037,17 +1037,20 @@ class GDBBreakpoint(object):
     def insert(self):
         # TODO: does removing the unicode-escape break things? what's the proper way to handle this in python3?
         # cmd = "-break-insert \"\\\"%s\\\":%d\"" % (self.original_filename.encode("unicode-escape"), self.original_line)
+        break_cmd = "-break-insert"
+        if get_setting("debug_ext") == True:
+            break_cmd += " -f"
         if self.addr != "":
-            cmd = "-break-insert *%s" % self.addr
+            cmd = "%s *%s" % (break_cmd, self.addr)
         else:
-            cmd = "-break-insert \"\\\"%s\\\":%d\"" % (self.original_filename, self.original_line)
+            cmd = "%s \"\\\"%s\\\":%d\"" % (break_cmd, self.original_filename, self.original_line)
         out = run_cmd(cmd, True)
         if get_result(out) == "error":
             return
         res = parse_result_line(out)
         if "bkpt" not in res and "matches" in res:
             for match in res["matches"]["b"]:
-                cmd = "-break-insert *%s" % match["addr"]
+                cmd = "%s *%s" % (break_cmd, match["addr"])
                 out = run_cmd(cmd, True)
                 if get_result(out) == "error":
                     return


### PR DESCRIPTION
When true, this allows setting breakpoints on externally loaded shared libraries. This PR fixes #49
