### PR TITLE
make the "GDB Console" view show the full program output, ...

### DIFF
--- a/sublimegdb.py
+++ b/sublimegdb.py
@@ -1394,7 +1394,7 @@ def gdboutput(pipe):
     sublime.set_timeout(update_view_markers, 0)
 
     for view in gdb_views:
-        sublime.set_timeout(view.on_session_ended, 0)
+        sublime.set_timeout(view.on_session_ended, 0.1)
     sublime.set_timeout(cleanup, 0)
 
 def cleanup():


### PR DESCRIPTION
... by setting a short timeout on each view.

As mentioned on the original PR, #50, a program's full output isn't shown in the "GDB Console" view. This ickle patch fixes that.
