### PR TITLE
Adding the gdb_timeout in settings to configure the gdb load time

### DIFF
--- a/SublimeGDB.sublime-settings
+++ b/SublimeGDB.sublime-settings
@@ -32,6 +32,11 @@
     // probably want to change this to -exec-continue
     "exec_cmd": "-exec-run",
 
+    // For the larger binaries with lot of shared libraries
+    // the loading within the gdb could take much longer.
+    // Configure the thead wait timeout by setting gdb_timeout
+    "gdb_timeout": 20,
+
     "layout":
     {
         "cols": [0.0, 0.33, 0.66, 1.0],

--- a/sublimegdb.py
+++ b/sublimegdb.py
@@ -1607,7 +1607,7 @@ class GdbLaunch(sublime_plugin.WindowCommand):
             t = threading.Thread(target=programio, args=(pty,tty))
             t.start()
             try:
-                run_cmd("-gdb-show interpreter", True, timeout=20)
+                run_cmd("-gdb-show interpreter", True, timeout=get_setting("gdb_timeout", 20))
             except:
                 sublime.error_message("""\
 It seems you're not running gdb with the "mi" interpreter. Please add


### PR DESCRIPTION
For a larger executable, the loading in gdb takes a lot longer time. Adding the gdb_timeout setting in order to configure the thread timeout.
