### PR TITLE
add terminate on exit gdb settings

### DIFF
--- a/SublimeGDB.sublime-settings
+++ b/SublimeGDB.sublime-settings
@@ -105,5 +105,8 @@
     "debug": true,
 
     // Disables showing the error message dialog when something goes wrong
-    "i_know_how_to_use_gdb_thank_you_very_much": false
+    "i_know_how_to_use_gdb_thank_you_very_much": false,
+
+    //Terminate gdb on exit
+    "terminate_on_exit": false
 }

--- a/sublimegdb.py
+++ b/sublimegdb.py
@@ -1276,6 +1276,9 @@ def run_cmd(cmd, block=False, mimode=True, timeout=10):
 
 def wait_until_stopped():
     if gdb_run_status == "running":
+        if get_setting("terminate_on_exit", False):
+            gdb_process.terminate()
+            return True    
         result = run_cmd("-exec-interrupt --all", True)
         if "^done" in result:
             i = 0


### PR DESCRIPTION
In GO debug gdb do not exit after `-exec-interrupt --all` when not set brakepoints, add terminate support for gdb exiting
