### PR TITLE
Add comments to 'layout' setting (without typos)

### DIFF
--- a/SublimeGDB.sublime-settings
+++ b/SublimeGDB.sublime-settings
@@ -39,7 +39,7 @@
     // Configure the thread wait timeout by setting gdb_timeout
     "gdb_timeout": 20,
 
-    // Define debuging window layout (window split)
+    // Define debugging window layout (window split)
     // first define column/row separators, then refer to them to define cells
     "layout":
     {


### PR DESCRIPTION
Comments are useful here, because:
- it's not obvious how to adjust `layout` setting
- `sublime.Window.set_layout()` isn't covered in sublime's official docs,
  it is covered only in [unofficial docs](http://sublime-text-unofficial-documentation.readthedocs.org/en/sublime-text-2/reference/api.html)
