### PR TITLE
Add hooks for getting Segger JLink to work.

### DIFF
--- a/Context.sublime-menu
+++ b/Context.sublime-menu
@@ -5,6 +5,8 @@
         { "caption": "-", "id": "breakpoints" },
         { "command": "gdb_toggle_breakpoint", "caption": "Toggle Breakpoint" },
         { "command": "gdb_launch", "caption": "Run"},
+        { "command": "gdb_load", "caption": "Load"},
+        { "command": "gdb_pause", "caption": "Pause"},
         { "command": "gdb_continue", "caption": "Continue" },
         { "command": "gdb_step_over", "caption": "Step Over" },
         { "command": "gdb_step_into", "caption": "Step Into" },

--- a/Readme.creole
+++ b/Readme.creole
@@ -1,7 +1,5 @@
 === Description ===
-GDB plugin for Sublime Text 2. Pull requests are more than welcome.
-
-This is still quite early so if you have any [[https://github.com/quarnster/SublimeGDB/issues?sort=created&direction=desc&state=open|issues or feature requests]], please let me know.
+GDB plugin for Sublime Text 2. Filing issues are not welcome (and thus disabled). Pull requests please.
 
 === Installation ===
     # The easiest way to install SublimeGDB is via the excellent Package Control Plugin

--- a/SublimeGDB.sublime-settings
+++ b/SublimeGDB.sublime-settings
@@ -37,6 +37,7 @@
     // "commandline": "gdb --interpreter=mi ./executable",
     "commandline": "notset",
 
+
     // Arguments for the program.
     // Example: to run "./executable foo bar"
     // "arguments": "foo bar"
@@ -44,10 +45,33 @@
     // "arguments": "< input.dat"
     "arguments": "",
 
+    // GDB Server 
+    // Specify a command and working dir for launching a GDB Server
+    // This is useful for dealing with "remote" servers that are actually locally 
+    // connected JTAG boxes
+    "server_workingdir": "notset",
+    "server_commandline": "notset",
+
     // The command to use to run the program.
     // If you are attaching to a remote program, you
     // probably want to change this to -exec-continue
     "exec_cmd": "-exec-run",
+
+    // Load the image to the remote target
+    "load_cmd": "-target-download",
+
+    // Immediately run the target upload connecting
+    // When attaching to a remote program, you
+    // may want to set this to false 
+    "run_after_init": true,
+
+    // Attempt to update stack information while the program is running
+    // If your remote target does not support non-stop, set this to false
+    "update_while_running" : true,
+
+    // Attach to a remote target?  This is needed here because "-gdb-set target-async 1" must be
+    // done prior to attaching
+    "attach_cmd" : "notset",
 
     // For the larger binaries with lot of shared libraries
     // the loading within the gdb could take much longer.

--- a/sublimegdb.py
+++ b/sublimegdb.py
@@ -1616,9 +1616,15 @@ class GdbLaunch(sublime_plugin.WindowCommand):
             gdb_server_cmd = get_setting("server_commandline", "notset")
             gdb_server_dir = get_setting("server_workingdir", "notset")
             if (gdb_server_cmd != "notset") and (gdb_server_dir != "notset"):
+
+                gdb_server_cmd = expand_path(gdb_server_cmd, self.window)
+                gdb_server_dir = expand_path(gdb_server_dir, self.window)
+                gdb_server_shell = get_setting("server_shell", False)
                 log_debug("gdb_server_cmd: %s" % gdb_server_cmd)
                 log_debug("gdb_server_dir: %s" % gdb_server_dir)
-                gdb_server_process = subprocess.Popen(gdb_server_cmd, shell=True, cwd=gdb_server_dir)
+                log_debug("gdb_server_dir: %s" % gdb_server_shell)
+                gdb_server_process = subprocess.Popen(gdb_server_cmd, shell=gdb_server_shell, cwd=gdb_server_dir)
+
 
             gdb_process = subprocess.Popen(commandline, shell=True, cwd=path,
                             stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/sublimegdb.py
+++ b/sublimegdb.py
@@ -126,6 +126,7 @@ gdb_bkp_view = None
 
 gdb_shutting_down = False
 gdb_process = None
+gdb_server_process = None
 gdb_stack_frame = None
 gdb_stack_index = 0
 
@@ -1320,11 +1321,14 @@ def update_cursor():
     global gdb_stack_index
     global gdb_stack_frame
 
+    if not get_setting("update_while_running", True) and gdb_run_status == "running":
+        return
+
     res = run_cmd("-stack-info-frame", True)
     if get_result(res) == "error":
         if gdb_run_status != "running":
             print("run_status is %s, but got error: %s" % (gdb_run_status, res))
-        return
+            return
     currFrame = parse_result_line(res)["frame"]
     gdb_stack_index = int(currFrame["level"])
 
@@ -1373,16 +1377,21 @@ def gdboutput(pipe):
         try:
             line = pipe.readline()
             if len(line) == 0:
+                log_debug("gdb_%s: broken pipe\n" % ("stdout" if pipe == gdb_process.stdout else "stderr"))
                 break
             line = line.strip().decode(sys.getdefaultencoding())
             log_debug("gdb_%s: %s\n" % ("stdout" if pipe == gdb_process.stdout else "stderr", line))
             gdb_session_view.add_line("%s\n" % line, False)
+
+            if pipe != gdb_process.stdout:
+                continue
 
             run_status = run_status_regex.match(line)
             if run_status is not None:
                 gdb_run_status = run_status.group(2)
                 reason = re.search("(?<=reason=\")[a-zA-Z0-9\-]+(?=\")", line)
                 if reason is not None and reason.group(0).startswith("exited"):
+                    log_debug("gdb: exiting %s" % line)
                     run_cmd("-gdb-exit")
                 elif not "running" in gdb_run_status and not gdb_shutting_down:
                     thread_id = re.search('thread-id="(\d+)"', line)
@@ -1562,6 +1571,7 @@ class GdbInput(sublime_plugin.WindowCommand):
 class GdbLaunch(sublime_plugin.WindowCommand):
     def run(self):
         global gdb_process
+        global gdb_server_process
         global gdb_run_status
         global gdb_bkp_window
         global gdb_bkp_view
@@ -1601,8 +1611,17 @@ class GdbLaunch(sublime_plugin.WindowCommand):
             if not os.path.exists(path):
                 sublime.error_message("The directory given does not exist: %s" % path)
                 return
+
+            # Optionally Launch the GDB Server
+            gdb_server_cmd = get_setting("server_commandline", "notset")
+            gdb_server_dir = get_setting("server_workingdir", "notset")
+            if (gdb_server_cmd != "notset") and (gdb_server_dir != "notset"):
+                log_debug("gdb_server_cmd: %s" % gdb_server_cmd)
+                log_debug("gdb_server_dir: %s" % gdb_server_dir)
+                gdb_server_process = subprocess.Popen(gdb_server_cmd, shell=True, cwd=gdb_server_dir)
+
             gdb_process = subprocess.Popen(commandline, shell=True, cwd=path,
-                                            stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                            stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
             log_debug("Process: %s\n" % gdb_process)
             gdb_bkp_window = sublime.active_window()
@@ -1661,13 +1680,20 @@ It seems you're not running gdb with the "mi" interpreter. Please add
                 run_cmd("-gdb-set disassembly-flavor att")
             # if gdb_nonstop:
             #     run_cmd("-gdb-set non-stop on")
-
+            attach_cmd = get_setting("attach_cmd","notset")
+            if(attach_cmd != "notset"):
+                run_cmd(attach_cmd)
             gdb_breakpoint_view.sync_breakpoints()
-            gdb_run_status = "running"
 
-            if arguments:
-                run_cmd("-exec-arguments " + arguments)
-            run_cmd(get_setting("exec_cmd", "-exec-run"), True)
+            if(get_setting("run_after_init", True)):
+                gdb_run_status = "running"
+                if arguments:
+                    run_cmd("-exec-arguments " + arguments)
+
+                run_cmd(get_setting("exec_cmd", "-exec-run"), True)
+            else:
+                gdb_run_status = "stopped"
+
 
             show_input()
         else:
@@ -1700,6 +1726,8 @@ class GdbExit(sublime_plugin.WindowCommand):
         gdb_shutting_down = True
         wait_until_stopped()
         run_cmd("-gdb-exit", True)
+        if gdb_server_process:
+            gdb_server_process.terminate()
 
     def is_enabled(self):
         return is_running()
@@ -1707,6 +1735,15 @@ class GdbExit(sublime_plugin.WindowCommand):
     def is_visible(self):
         return is_running()
 
+class GdbLoad(sublime_plugin.WindowCommand):
+    def run(self):
+        run_cmd(get_setting("load_cmd", "-target-download"))
+
+    def is_enabled(self):
+        return is_running() and gdb_run_status != "running"
+
+    def is_visible(self):
+        return is_running() and gdb_run_status != "running"
 
 class GdbPause(sublime_plugin.WindowCommand):
     def run(self):

--- a/sublimegdb.py
+++ b/sublimegdb.py
@@ -841,13 +841,17 @@ class GDBCallstackView(GDBView):
 
 
 class GDBThread:
-    def __init__(self, id, state="UNKNOWN", func="???()"):
+    def __init__(self, id, state="UNKNOWN", func="???()", details=None):
         self.id = id
         self.state = state
         self.func = func
+        self.details = details
 
     def format(self):
-        return "%03d - %10s - %s\n" % (self.id, self.state, self.func)
+        if self.details:
+            return "%03d - %10s - %s - %s\n" % (self.id, self.state, self.details, self.func)
+        else:
+            return "%03d - %10s - %s\n" % (self.id, self.state, self.func)
 
 
 class GDBThreadsView(GDBView):
@@ -899,7 +903,8 @@ class GDBThreadsView(GDBView):
                             if "value" in arg:
                                 args += " = " + arg["value"]
                     func = "%s(%s);" % (func, args)
-                self.threads.append(GDBThread(int(thread["id"]), thread["state"], func))
+                print("thread %s" % thread)
+                self.threads.append(GDBThread(int(thread["id"]), thread["state"], func, thread["details"]))
 
         if "current-thread-id" in ids:
             self.current_thread = int(ids["current-thread-id"])


### PR DESCRIPTION
I tweaked a couple things to allow a Segger JLink to work correctly.  The changes should be equally applicable to other JTAG boxes, however.

An example of the config file to activate the changes
```
    "sublimegdb_exec_cmd": "-exec-continue",
    "sublimegdb_attach_cmd" : "target extended-remote :2331",
    "sublimegdb_update_while_running": false,
    "sublimegdb_run_after_init": false,
    "sublimegdb_commandline": "arm-none-eabi-gdb  -nx -readnow -fullname --interpreter=mi -args ./Demo.elf",
    "sublimegdb_workingdir": "${folder:${project_path:../../build/Demo.elf}}",

    "sublimegdb_server_commandline": "JLinkGDBServer.exe -device \"Cyclone V\" -if JTAG -speed 4000",
    "sublimegdb_server_workingdir": "c:\\Program Files (x86)\\SEGGER\\JLink_V496d\\"
```

Without those settings, things should revert back to their previous behavior.  Hopefully this will keep it from breaking anyone else.
