### PR TITLE
Better path resolv for workingdir.

### DIFF
--- a/SublimeGDB.sublime-settings
+++ b/SublimeGDB.sublime-settings
@@ -10,6 +10,19 @@
     //      "sublimegdb_commandline": "gdb --interpreter=mi ./your_executable_name"
     //
     // }
+    // 
+    // generalized pattern for using always the current open file with an executable name 
+    // as the current file
+    // "settings":
+    // {
+    //      "sublimegdb_workingdir": "${folder: ${file}}",
+    //      // put your arguments hear
+    //      "sublimegdb_arguments": "",
+    //      // NOTE: You MUST provide --interpreter=mi for the plugin to work
+    //      "sublimegdb_commandline": "gdb --interpreter=mi --args ./${file_base_name}"
+    //      
+    //
+    // }
     //
     // ${home}, ${project_path:}, ${folder:}, ${file} and ${file_base_name}
     // tokens can be used in 'workingdir', 'commandline', 'arguments' options.

--- a/sublimegdb.py
+++ b/sublimegdb.py
@@ -95,16 +95,18 @@ def expand_path(value, window):
             for path in [os.path.join(f, m.group('file'))] \
             if os.path.exists(path) \
         ]
-    value = re.sub(r'\${project_path:(?P<file>[^}]+)}', lambda m: len(get_existing_files(m)) > 0 and get_existing_files(m)[0] or m.group('file'), value)
-    value = re.sub(r'\${env:(?P<variable>.*)}', lambda m: os.getenv(m.group('variable')), value)
-    if os.getenv("HOME"):
-        value = re.sub(r'\${home}', re.escape(os.getenv('HOME')), value)
-    value = re.sub(r'\${folder:(?P<file>.*)}', lambda m: os.path.dirname(m.group('file')), value)
     view = window.active_view()
     file_name = view.file_name();
+    # replace variable with values
     if file_name:
         value = re.sub(r'\${file}', lambda m: file_name, value)
         value = re.sub(r'\${file_base_name}', lambda m: os.path.splitext(os.path.basename(file_name))[0], value)
+    if os.getenv("HOME"):
+        value = re.sub(r'\${home}', re.escape(os.getenv('HOME')), value)
+    value = re.sub(r'\${env:(?P<variable>.*)}', lambda m: os.getenv(m.group('variable')), value)
+    # search in projekt for path and get folder from path
+    value = re.sub(r'\${project_path:(?P<file>[^}]+)}', lambda m: len(get_existing_files(m)) > 0 and get_existing_files(m)[0] or m.group('file'), value)
+    value = re.sub(r'\${folder:(?P<file>.*)}', lambda m: os.path.dirname(m.group('file')), value)
     value = value.replace('\\', os.sep)
     value = value.replace('/', os.sep)
 


### PR DESCRIPTION
The substitution of file file, file_base_name, HOME and other env is done before resolving project_path and folder.
This seams more reasonable to me as it allows more general statements. 
Its now possible to use statements like:

sublimegdb_workingdir": "${folder: ${file}}"

