### PR TITLE
+ Added support of pretty-printers

### DIFF
--- a/SublimeGDB.sublime-settings
+++ b/SublimeGDB.sublime-settings
@@ -163,6 +163,29 @@
     // Whether to log the raw data read from and written to the gdb session and the inferior program.
     "debug": true,
 
+    // Enables pretty printing. For example:
+    //
+    // std::string testStdString = "Foobar"
+    // -std::vector<int, std::allocator<int> > someVectorOfInt = {...}
+    //  int [0] = 1
+    //  int [1] = 2
+    //  int [2] = 3
+    //  int [3] = 4
+    //
+    // To enable this feature, it should be enabled is gdb too, see this: https://sourceware.org/gdb/wiki/STLSupport
+    // You should checkout latest printers:
+    // svn co svn://gcc.gnu.org/svn/gcc/trunk/libstdc++-v3/python
+    // And add to ~/.gdbinit the following:
+    //
+    // python
+    // import sys
+    // sys.path.insert(0, '<path to "python" directory>')
+    // from libstdcxx.v6.printers import register_libstdcxx_printers
+    // register_libstdcxx_printers (None)
+    // end
+    //
+    "enable_pretty_printing": true,
+
     // Disables showing the error message dialog when something goes wrong
     "i_know_how_to_use_gdb_thank_you_very_much": false
 }

--- a/sublimegdb.py
+++ b/sublimegdb.py
@@ -417,12 +417,14 @@ class GDBVariable:
 
     def expand(self):
         self.is_expanded = True
-        if not (len(self.children) == 0 and int(self.valuepair["numchild"]) > 0):
+        if not (len(self.children) == 0 and self.has_children() > 0):
             return
         self.add_children(self.get_name())
 
     def has_children(self):
-        return int(self.valuepair["numchild"]) > 0
+        numchild = int(self.valuepair["numchild"])
+        more = 0 if "has_more" not in self.valuepair else int(self.valuepair["has_more"])
+        return numchild > 0 or more > 0
 
     def collapse(self):
         self.is_expanded = False
@@ -1707,6 +1709,9 @@ It seems you're not running gdb with the "mi" interpreter. Please add
             else:
                 gdb_run_status = "stopped"
 
+            if(get_setting("enable_pretty_printing", True)):
+                run_cmd("-enable-pretty-printing")
+            
 
             show_input()
         else:


### PR DESCRIPTION
This enables more compact and expressive printing of variables that have pretty-printer scripts. Python libstdc++ printers can prettify all stl containers. User may have own collection of printers for specific data types, that also should work.

To enable libstdc++ printers see this: https://sourceware.org/gdb/wiki/STLSupport

Some examples:

![screenshot from 2015-11-09 00 20 51](https://cloud.githubusercontent.com/assets/3229783/11026782/59c8bc00-867c-11e5-96de-7df0dfde17a8.png)

![screenshot from 2015-11-09 00 20 06](https://cloud.githubusercontent.com/assets/3229783/11026786/5e5834b2-867c-11e5-8a2b-929ecfbe3251.png)

![screenshot from 2015-11-09 00 43 43](https://cloud.githubusercontent.com/assets/3229783/11026788/61cca704-867c-11e5-9fa8-a18466788e9d.png)
