### PR TITLE
Allow executable-specific settings for projects with multiple executables

### DIFF
--- a/Readme.creole
+++ b/Readme.creole
@@ -21,6 +21,7 @@ In short:
 * Open up the default settings via the command palette and begin typing GDB and select the default.
 * See what options are available, and open up the User SublimeGDB preferences to tweak any values
 * If you have multiple projects, you most likely want to put project specific setting in your project file, with a prefixed "sublimegdb_". See the comments at the top of the default SublimeGDB preferences for an example.
+* If you have multiple executables in the same project, you can add a "sublimegdb_executables" setting to your project settings, and add an entry for each executable's settings.
 * Once you're all configured, you can toggle breakpoints with F9 (OSX Users might want to change the key binding, or disable the "Exposé and Spaces" key bindings in the System Preferences)
 * Launch with F5
 * Step over with F10

--- a/SublimeGDB.sublime-settings
+++ b/SublimeGDB.sublime-settings
@@ -24,6 +24,34 @@
     //
     // }
     //
+    // If you want to debug different executables as part of the same project, you can add something
+    // like this to your project settings:
+    //
+    // "settings":
+    // {
+    //      "sublimegdb_executables":
+    //      {
+    //          "first_executable_name":
+    //          {
+    //              "workingdir": "${folder:${project_path:first_executable_name}}",
+    //              "commandline": "gdb --interpreter=mi ./first_executable"
+    //          },
+    //          "second_executable_name":
+    //          {
+    //              "workingdir": "${folder:${project_path:second_executable_name}}",
+    //              "commandline": "gdb --interpreter=mi ./second_executable"
+    //          }
+    //      }
+    // }
+    //
+    // When you start debugging, you will be prompted to choose from one of your executables. Any
+    // settings not specified for that project will be searched in your project settings (with a
+    // sublimegdb_ prefix), then in your user settings, then in the default settings.
+    //
+    // (Note: if you have multiple executables, and you have a breakpoint set in a source file which
+    // is not included in the current executable, you may have to set either debug_ext or
+    // i_know_how_to_use_gdb_thank_you_very_much.)
+    //
     // ${home}, ${project_path:}, ${folder:}, ${file} and ${file_base_name}
     // tokens can be used in 'workingdir', 'commandline', 'arguments' options.
     //


### PR DESCRIPTION
For example, maybe you have a unit tests target and a main target. I've found myself in this situation quite a bit.

The user will be prompted to choose an executable on launching gdb. Any settings not specified in the executable-specific settings will be searched on the same path as before (thus this is compatible with any existing settings files).

More description in the readme and in SublimeGDB.sublime-settings.