### PR TITLE
Explicit count modifiers

### DIFF
--- a/gdb.tmLanguage
+++ b/gdb.tmLanguage
@@ -258,7 +258,7 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>\\(?:\\|[abefnprtv'"?]|[0-3]\d{,2}|[4-7]\d?|x[a-fA-F0-9]{,2}|u[a-fA-F0-9]{,4}|U[a-fA-F0-9]{,8})</string>
+					<string>\\(?:\\|[abefnprtv'"?]|[0-3]\d{0,2}|[4-7]\d?|x[a-fA-F0-9]{0,2}|u[a-fA-F0-9]{0,4}|U[a-fA-F0-9]{0,8})</string>
 					<key>name</key>
 					<string>constant.character.escape.gdb</string>
 				</dict>

--- a/gdb_session.tmLanguage
+++ b/gdb_session.tmLanguage
@@ -12,7 +12,7 @@
             <array>
                 <dict>
                     <key>match</key>
-                    <string>\\(\\|[abefnprtv'"?]|[0-3]\d{,2}|[4-7]\d?|x[a-fA-F0-9]{,2}|u[a-fA-F0-9]{,4}|U[a-fA-F0-9]{,8})</string>
+                    <string>\\(\\|[abefnprtv'"?]|[0-3]\d{0,2}|[4-7]\d?|x[a-fA-F0-9]{0,2}|u[a-fA-F0-9]{0,4}|U[a-fA-F0-9]{0,8})</string>
                     <key>name</key>
                     <string>constant.character.escape.c</string>
                 </dict>


### PR DESCRIPTION
The construction {,n} in regular expressions is only supported by Oniguruma (which is used by TextMate). This Sublime Text package is used to highlight GDB code on github.com. However, github.com is using a PCRE-based engine for regexes.

This pull request fixes that by using explicit count modifiers.