### PR TITLE
Add memdump view along variables

### DIFF
--- a/Context.sublime-menu
+++ b/Context.sublime-menu
@@ -52,6 +52,10 @@
         {
             "caption": "Add watch",
             "command": "gdb_add_watch"
+        },
+        {
+            "caption": "Set variable format",
+            "command": "gdb_set_var_fmt"
         }
     ]
 }]

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -84,5 +84,9 @@
     {
         "caption": "SublimeGDB: Open Threads View",
         "command": "gdb_open_threads_view"
+    },
+    {
+        "caption": "SublimeGDB: Add MemDump",
+        "command": "gdb_add_mem_dump"
     }
 ]

--- a/sublimegdb.py
+++ b/sublimegdb.py
@@ -745,11 +745,11 @@ class GDBMemDump:
         else:
             icon = "+"
 
-        output += "%sDUMP of %s\n" % (icon, self.exp)
+        self.children = list()
+        output += "%sDUMP of %s %s\n" % (icon, self.exp, "//(NOT IN SCOPE)" if not self.data else "")
         indent = "    "
         self.line = line
 
-        self.children = list()
         
         if self.is_expanded and 'memory' in self.data:
             for l in self.data['memory']:

--- a/sublimegdb.py
+++ b/sublimegdb.py
@@ -2306,8 +2306,16 @@ class GdbSetVarFmt(sublime_plugin.TextCommand):
 
 class GdbAddMemDump(sublime_plugin.TextCommand):
     def run(self, edit):
-        gdb_variables_view.variables.append(GDBMemDump("c", 5))
-        gdb_variables_view.update_variables(True)
+        expression = [""]
+        length = [0]
+        def on_memdump_explen(l):
+            length[0] = int(l)
+            gdb_variables_view.variables.append(GDBMemDump(expression[0], length[0]))
+            gdb_variables_view.update_variables(True)
+        def on_memdump_expdone(exp):
+            expression[0] = exp
+            self.view.window().show_input_panel("Memdump length", "", on_memdump_explen, None, None)
+        self.view.window().show_input_panel("Memdump Expression", "", on_memdump_expdone, None, None)
         
 
 

--- a/sublimegdb.py
+++ b/sublimegdb.py
@@ -602,7 +602,7 @@ class GDBMemDumpChild:
 class GDBMemDump:
     def __init__(self, exp, memlen, wordlen=1, vp=None, parent=None):
         self.parent = parent
-        self.valuepair = vp
+        self.valuepair = vp if vp else {'exp': exp}
         self.line = 0
         self.is_expanded = True
         self.dirty = True

--- a/sublimegdb.py
+++ b/sublimegdb.py
@@ -606,7 +606,7 @@ class GDBMemDump:
         self.is_expanded = True
         self.dirty = True
         self.deleted = False
-        self.cols = 5
+        self.cols = get_setting("memdump_cols", 4)
         self.len = memlen
         self.exp = exp
         self.expfmt = "x"

--- a/sublimegdb.py
+++ b/sublimegdb.py
@@ -645,6 +645,8 @@ class GDBMemDump:
                 if(newdat[i] != olddat[i] and idx*self.cols+i < self.len):
                     fieldlen = len(newdat[i]) if self.expfmt != "x" else len(newdat[i])-2
                     regions.append(sublime.Region(view.text_point(self.line+idx+1, i*(fieldlen+1)+offset), view.text_point(self.line+idx+1, i*(fieldlen+1)+fieldlen)+offset))
+                    if self.data['memory'][idx]['ascii']:
+                        regions.append(sublime.Region(view.text_point(self.line+idx+1, (self.cols*(fieldlen+1))+offset+3+i), view.text_point(self.line+idx+1, (self.cols*(fieldlen+1))+offset+3+i+1)))
         return regions
 
     def update(self, d):

--- a/sublimegdb.py
+++ b/sublimegdb.py
@@ -712,7 +712,7 @@ class GDBMemDump:
         
         if self.is_expanded:
             for l in self.data['memory']:
-                output += "%s%s\n" % (indent, self.fmt_line(l['data'], line))
+                output += "%s%s: %s\n" % (indent, l['addr'].upper(),self.fmt_line( l['data'], line))
                 line += 1
                 self.children.append(GDBMemDumpChild(line, self))
 

--- a/sublimegdb.py
+++ b/sublimegdb.py
@@ -693,6 +693,13 @@ class GDBMemDump:
     def is_dirty(self):
         return self.dirty
 
+    def fmt_line(self, data, line):
+        dat = data[:max(self.len-((line-self.line)*self.cols),0)]
+        if self.expfmt == "x":
+            return " ".join([x[2:].upper() for x in dat])
+        else:
+            return " ".join(dat)
+
     def format(self, indent="", output="", line=0, dirty=[]):
         if self.is_expanded:
             icon = "-"
@@ -705,7 +712,7 @@ class GDBMemDump:
         
         if self.is_expanded:
             for l in self.data['memory']:
-                output += "%s%s\n" % (indent, " ".join(l['data']))
+                output += "%s%s\n" % (indent, self.fmt_line(l['data'], line))
                 line += 1
                 self.children.append(GDBMemDumpChild(line, self))
 

--- a/sublimegdb.py
+++ b/sublimegdb.py
@@ -630,21 +630,22 @@ class GDBMemDump:
 
     def getchanged(self, view):
         regions = []
+        if not self.is_expanded:
+            return regions
 
         if not 'memory' in self.oldata:
-            print("No old data")
             return regions
-        for idx, (d, od) in enumerate(zip(self.data['memory'], self.oldata['memory'])):
-            newdat = d['data']
-            olddat = od['data'] if 'data' in od else None
-            offset = 6 + len(d['addr'])
+        for idx in range(len(self.data['memory'])):
+            newdat = self.data['memory'][idx]['data']
+            olddat = self.oldata['memory'][idx]['data'] if self.oldata else None
+            offset = 6 + len(self.data['memory'][idx]['addr'])
             if not olddat:
                 continue
             for i in range(len(newdat)):
-                if(newdat[i] != olddat[i]):
+                if(newdat[i] != olddat[i] and idx*self.cols+i < self.len):
                     fieldlen = len(newdat[i]) if self.expfmt != "x" else len(newdat[i])-2
                     regions.append(sublime.Region(view.text_point(self.line+idx+1, i*(fieldlen+1)+offset), view.text_point(self.line+idx+1, i*(fieldlen+1)+fieldlen)+offset))
-            return regions
+        return regions
 
     def update(self, d):
         pass

--- a/sublimegdb.py
+++ b/sublimegdb.py
@@ -761,6 +761,7 @@ class GDBMemDump:
                 line += 1
                 self.children.append(GDBMemDumpChild(line, self))
 
+        line += 1
         return (output, line)
 
     @staticmethod

--- a/sublimegdb.py
+++ b/sublimegdb.py
@@ -31,6 +31,7 @@ import traceback
 import os
 import sys
 import re
+import math
 import queue
 from datetime import datetime
 from functools import partial
@@ -611,7 +612,7 @@ class GDBMemDump:
         self.exp = exp
         self.expfmt = "x"
         self.wordlen = wordlen
-        self.rows = self.len // self.cols + 1
+        self.rows = math.ceil(float(self.len) / self.cols)
         self.data = {}
         self.oldata = {}
         self.children = []
@@ -642,11 +643,14 @@ class GDBMemDump:
         if not self.is_expanded:
             return regions
 
-        if not 'memory' in self.oldata:
+        if not 'memory' in self.oldata or not 'memory' in self.data:
             return regions
         for idx in range(len(self.data['memory'])):
             newdat = self.data['memory'][idx]['data']
             olddat = self.oldata['memory'][idx]['data'] if self.oldata else None
+            # calculating the regions is a bit tricky because all characters in a line have to be included in the calc.
+            # one byte is displayed within fieldlen plus one space characters
+            # the comment sign takes 3 chars with one space included
             offset = 6 + len(self.data['memory'][idx]['addr'])
             if not olddat:
                 continue

--- a/sublimegdb.py
+++ b/sublimegdb.py
@@ -621,9 +621,15 @@ class GDBMemDump:
 
     def update_value(self):
         line = run_cmd("-data-read-memory %s %s %d %d %d \".\"" % (self.exp, self.expfmt, self.wordlen, self.rows, self.cols) , True)
-        if get_result(line) == "done":
+        if get_result(line, False) == "done":
             self.oldata = self.data
             self.data = parse_result_line(line)
+            self.deleted = False
+        else:
+            self.oldata = self.data
+            self.data = {}
+            self.deleted = True
+
 
     def set_fmt(self, fmt):
         pass
@@ -740,7 +746,7 @@ class GDBMemDump:
         indent = "    "
         self.line = line
         
-        if self.is_expanded:
+        if self.is_expanded and 'memory' in self.data:
             for l in self.data['memory']:
                 output += "%s%s: %s\n" % (indent, l['addr'].upper().replace("X", "x"),self.fmt_line(l['data'], l['ascii'] if 'ascii' in l else None, line))
                 line += 1

--- a/sublimegdb.py
+++ b/sublimegdb.py
@@ -1035,6 +1035,11 @@ class GDBVariablesView(GDBView):
                 var.delete()
             args = self.extract_varnames(parse_result_line(run_cmd("-stack-list-arguments 0 %d %d" % (gdb_stack_index, gdb_stack_index), True))["stack-args"]["frame"]["args"])
             self.variables = []
+            
+            memdumps = get_setting("memdumps", [])
+            for m in memdumps:
+                self.variables.append(GDBMemDump(m['exp'], m['words'], wordlen=m['wordlen']))
+
             for arg in args:
                 self.add_variable(arg)
             loc = self.extract_varnames(parse_result_line(run_cmd("-stack-list-locals 0", True))["locals"])

--- a/sublimegdb.py
+++ b/sublimegdb.py
@@ -616,6 +616,7 @@ class GDBMemDump:
         self.data = {}
         self.oldata = {}
         self.children = []
+        self.update_value()
 
     def delete(self):
         self.deleted = True


### PR DESCRIPTION
This pull request adds a mighty feature to sublimeGDB, i.e. memory dumps just as you would get with x/x in GDB. The changed bytes are highlighted, and the memdump detects whether an expression goes out of scope. Also, you can predefine memdumps in your project file to re-appear once you restart debugging.

Example:
`"sublimegdb_memdumps": [
			{
				"exp": "c",
				"words": 12,
				"wordlen": 1
			}]`

Also, the radix of a variable can be changed live in the GDB Variables window by right clicking on the variable and selecting the "Set variable format" command.